### PR TITLE
[#95] REFACTOR: 네이버 부동산 api 크롤링 과정 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     // SMS
     implementation 'net.nurigo:sdk:4.3.0'
 
+    // caffeine
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/org/silsagusi/joonggaemoa/domain/article/dataProvider/ArticleDataProvider.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/domain/article/dataProvider/ArticleDataProvider.java
@@ -1,0 +1,23 @@
+package org.silsagusi.joonggaemoa.domain.article.dataProvider;
+
+import java.util.List;
+
+import org.silsagusi.joonggaemoa.domain.article.entity.Article;
+import org.silsagusi.joonggaemoa.domain.article.repository.ArticleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleDataProvider {
+
+	private final ArticleRepository articleRepository;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void saveArticles(List<Article> articles) {
+		articleRepository.saveAll(articles);
+	}
+}

--- a/src/main/java/org/silsagusi/joonggaemoa/domain/article/entity/RegionScrapStatus.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/domain/article/entity/RegionScrapStatus.java
@@ -1,11 +1,16 @@
 package org.silsagusi.joonggaemoa.domain.article.entity;
 
-import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "region_scrap_statuses")
@@ -26,6 +31,10 @@ public class RegionScrapStatus {
 
 	private LocalDateTime lastScrapedAt;
 
+	private Boolean failed;
+
+	private String errorMessage;
+
 	public RegionScrapStatus(Region region, Integer lastScrapedPage, Boolean completed, LocalDateTime lastScrapedAt) {
 		this.region = region;
 		this.lastScrapedPage = lastScrapedPage;
@@ -40,5 +49,10 @@ public class RegionScrapStatus {
 
 	public void updateCompleted(Boolean completed) {
 		this.completed = completed;
+	}
+
+	public void updateFailed(Boolean failed, String errorMessage) {
+		this.failed = failed;
+		this.errorMessage = errorMessage;
 	}
 }

--- a/src/main/java/org/silsagusi/joonggaemoa/global/config/AsyncConfig.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package org.silsagusi.joonggaemoa.global.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+	@Bean(name = "scrapExecutor")
+	public Executor scrapExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(1);
+		executor.setMaxPoolSize(5);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("scrapExecutor-");
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/java/org/silsagusi/joonggaemoa/global/config/CacheConfig.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/global/config/CacheConfig.java
@@ -1,0 +1,27 @@
+package org.silsagusi.joonggaemoa.global.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+	@Bean
+	public CacheManager cacheManager() {
+		Caffeine<Object, Object> caffeine = Caffeine.newBuilder()
+			.expireAfterWrite(1, TimeUnit.HOURS)
+			.maximumSize(10000);
+
+		CaffeineCacheManager cacheManager = new CaffeineCacheManager("addressCache");
+		cacheManager.setCaffeine(caffeine);
+		return cacheManager;
+	}
+}

--- a/src/main/java/org/silsagusi/joonggaemoa/request/naverland/service/KakaoAddressLookupService.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/request/naverland/service/KakaoAddressLookupService.java
@@ -1,11 +1,13 @@
 package org.silsagusi.joonggaemoa.request.naverland.service;
 
+import org.silsagusi.joonggaemoa.request.naverland.client.KakaoApiClient;
+import org.silsagusi.joonggaemoa.request.naverland.service.dto.AddressResponse;
+import org.silsagusi.joonggaemoa.request.naverland.service.dto.Coord2AddressResponse;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.silsagusi.joonggaemoa.request.naverland.service.dto.AddressResponse;
-import org.silsagusi.joonggaemoa.request.naverland.client.KakaoApiClient;
-import org.silsagusi.joonggaemoa.request.naverland.service.dto.Coord2AddressResponse;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +17,7 @@ public class KakaoAddressLookupService implements AbstractAddressLookupService {
 	private final KakaoApiClient kakaoApiClient;
 
 	@Override
+	@Cacheable(value = "addressCache", key = "#latitude + ':' + #longitude")
 	public AddressResponse lookupAddress(double latitude, double longitude)
 		throws NullPointerException {
 
@@ -28,7 +31,7 @@ public class KakaoAddressLookupService implements AbstractAddressLookupService {
 
 		Coord2AddressResponse.Document doc = response.getDocuments().get(0);
 
-		if ( doc.getAddress() == null ) {
+		if (doc.getAddress() == null) {
 			log.warn("주소 정보 없음: lat={}, lon={}", latitude, longitude);
 			return null;  // Return null or handle as needed
 		} else {
@@ -39,7 +42,7 @@ public class KakaoAddressLookupService implements AbstractAddressLookupService {
 			String mainAddressNo = doc.getAddress().getMainAddressNo();
 			String subAddressNo = doc.getAddress().getSubAddressNo();
 
-			if ( doc.getRoadAddress() == null ) {
+			if (doc.getRoadAddress() == null) {
 				log.warn("도로명 주소 정보 없음: lat={}, lon={}", latitude, longitude);
 				return new AddressResponse(lotAddress, null,
 					city, district, town, mainAddressNo, subAddressNo,


### PR DESCRIPTION
## 💡 개요
[문제 상황]
프로젝트 시작하고 얼마 되지않아 커넥션 풀이 바닥나는 현상이 발생하였습니다
기존 크롤링 과정은 Schedule -> Job -> Step 순으로 이어지는데 Step에서 Chunk기반으로 50개의 Region을 받아옵니다
각 Region 별로 여러 번 외부 API 호출 + 저장 + Thread.sleep(3~7초) 가 반복되었습니다

[변경점]
Chunk 방식을 Tasklet방식으로 변경하였습니다
외부 API 요청 과정은 비동기로 처리하였습니다
저장 트랜잭션을 REQUIRES_NEW로 변경하였습니다
실패처리를 위해 flag를 남기고 에러메세지를 기록하였습니다
주소 정보를 위한 카카오 API는 캐시 처리하였습니다

Resolves: #95 

## 🔧 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
