### PR TITLE
[#137] FEAT: 매물 api에 좌표값 추가

### DIFF
--- a/src/main/java/org/silsagusi/joonggaemoa/api/article/controller/ArticleController.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/api/article/controller/ArticleController.java
@@ -31,10 +31,14 @@ public class ArticleController {
 		@RequestParam(required = false) List<String> realEstateType,
 		@RequestParam(required = false) List<String> tradeType,
 		@RequestParam(required = false) String minPrice,
-		@RequestParam(required = false) String maxPrice
+		@RequestParam(required = false) String maxPrice,
+		@RequestParam(required = false) Double latitude,
+		@RequestParam(required = false) Double longitude
 	) {
 		return ResponseEntity.ok(ApiResponse.ok(
-			articleService.getAllArticles(pageable, realEstateType, tradeType, minPrice, maxPrice)
+			articleService.getAllArticles(
+				pageable, realEstateType, tradeType, minPrice, maxPrice, latitude, longitude
+			)
 		));
 	}
 

--- a/src/main/java/org/silsagusi/joonggaemoa/api/article/controller/ArticleController.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/api/article/controller/ArticleController.java
@@ -31,13 +31,11 @@ public class ArticleController {
 		@RequestParam(required = false) List<String> realEstateType,
 		@RequestParam(required = false) List<String> tradeType,
 		@RequestParam(required = false) String minPrice,
-		@RequestParam(required = false) String maxPrice,
-		@RequestParam(required = false) Double latitude,
-		@RequestParam(required = false) Double longitude
+		@RequestParam(required = false) String maxPrice
 	) {
 		return ResponseEntity.ok(ApiResponse.ok(
 			articleService.getAllArticles(
-				pageable, realEstateType, tradeType, minPrice, maxPrice, latitude, longitude
+				pageable, realEstateType, tradeType, minPrice, maxPrice
 			)
 		));
 	}

--- a/src/main/java/org/silsagusi/joonggaemoa/api/article/service/ArticleService.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/api/article/service/ArticleService.java
@@ -36,9 +36,7 @@ public class ArticleService {
 		List<String> realEstateType,
 		List<String> tradeType,
 		String minPrice,
-		String maxPrice,
-		Double latitude,
-		Double longitude
+		String maxPrice
 	) {
 		Specification<Article> spec = Specification.where(null);
 

--- a/src/main/java/org/silsagusi/joonggaemoa/api/article/service/ArticleService.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/api/article/service/ArticleService.java
@@ -36,7 +36,9 @@ public class ArticleService {
 		List<String> realEstateType,
 		List<String> tradeType,
 		String minPrice,
-		String maxPrice
+		String maxPrice,
+		Double latitude,
+		Double longitude
 	) {
 		Specification<Article> spec = Specification.where(null);
 

--- a/src/main/java/org/silsagusi/joonggaemoa/api/article/service/dto/ArticleResponse.java
+++ b/src/main/java/org/silsagusi/joonggaemoa/api/article/service/dto/ArticleResponse.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 @Builder
 public class ArticleResponse {
 	private Long id;
+	private Double latitude;
+	private Double longitude;
 	private String cortarNo;
 	private String articleNo;
 	private String name;
@@ -35,6 +37,8 @@ public class ArticleResponse {
 	public static ArticleResponse of(Article article) {
 		return ArticleResponse.builder()
 			.id(article.getId())
+			.latitude(article.getLatitude())
+			.longitude(article.getLongitude())
 			.cortarNo(article.getCortarNo())
 			.articleNo(article.getArticleNo())
 			.name(article.getName())


### PR DESCRIPTION
## 💡 개요
부동산 지도 화면 구현을 위해 API 응답값에 좌표값(latitude, longitude)을 불러오게끔 ArticleResponse, ArticleService, ArticleController 를 수정하였습니다.

Resolves: #137

## 🔧 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
