### PR TITLE
[#145] REFACTOR: custom response 수정

### DIFF
--- a/core/src/main/java/org/silsagusi/core/customResponse/ApiResponse.java
+++ b/core/src/main/java/org/silsagusi/core/customResponse/ApiResponse.java
@@ -3,8 +3,8 @@ package org.silsagusi.core.customResponse;
 import org.silsagusi.core.customResponse.exception.CustomException;
 import org.silsagusi.core.customResponse.exception.ExceptionDto;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import jakarta.annotation.Nullable;
@@ -16,27 +16,24 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ApiResponse<T> {
 
-	@JsonIgnore
-	HttpStatus httpStatus;
 	boolean success;
 	@Nullable
 	T data;
 	@Nullable
 	ExceptionDto error;
 
+	@ResponseStatus(HttpStatus.OK)
 	public static <T> ApiResponse<T> ok() {
-		return new ApiResponse<>(HttpStatus.OK, true, null, null);
+		return new ApiResponse<>(true, null, null);
 	}
 
+	@ResponseStatus(HttpStatus.OK)
 	public static <T> ApiResponse<T> ok(final T data) {
-		return new ApiResponse<>(HttpStatus.OK, true, data, null);
+		return new ApiResponse<>(true, data, null);
 	}
 
-	public static <T> ApiResponse<T> created(@Nullable final T data) {
-		return new ApiResponse<>(HttpStatus.CREATED, true, data, null);
-	}
-
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public static <T> ApiResponse<T> fail(final CustomException e) {
-		return new ApiResponse<>(HttpStatus.BAD_REQUEST, false, null, ExceptionDto.of(e.getErrorCode()));
+		return new ApiResponse<>(false, null, ExceptionDto.of(e.getErrorCode()));
 	}
 }


### PR DESCRIPTION
## 💡 개요
응답이 나가기 전 interceptor에서 http status를 추가하였었는데, 응답 코드가 4자리로 변경되면서 사용하지 않게 되었습니다
그래서 custom response의 http status필드를 제거하였습니다
자체적인 응답코드를 사용하지만 알아보기 쉽게 하기 위해 @ResponseStatus를 사용하여 성공이면 200, 실패면 400을 나타내도록 하였습니다

Resolves: #145 

## 🔧 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
