### PR TITLE
[#193] FIX: question의 options 초기화 후 반환

### DIFF
--- a/api/src/main/java/org/silsagusi/api/survey/application/mapper/SurveyMapper.java
+++ b/api/src/main/java/org/silsagusi/api/survey/application/mapper/SurveyMapper.java
@@ -85,7 +85,7 @@ public class SurveyMapper {
 			.content(question.getContent())
 			.type(question.getType())
 			.isRequired(question.getIsRequired())
-			.options(question.getOptions())
+			.options(new ArrayList<>(question.getOptions()))
 			.build();
 	}
 


### PR DESCRIPTION
## 💡 개요
options 필드는 @ElementCollection으로 매핑되어 있고 기본 fetch = LAZY 상태라서 실제로 값을 꺼낼 때까지는 프록시 객체(PersistentBag) 상태입니다.
그런데 컨트롤러에서 DTO로 반환하거나 @responsebody로 JSON 변환하는 순간 스프링이 options 필드에 접근하면서 값을 꺼내려 하는데 이미 영속성 컨텍스트(session)가 닫혀 있어서 Lazy 로딩 실패하고 예외가 발생합니다
그래서 options를 새 List으로 반환하도록 하였습니다

Resolves: #193 

## 🔧 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
