### PR TITLE
[#269] REFACTOR: 대시보드 입장 API 속도 개선

### DIFF
--- a/api/src/main/java/org/silsagusi/api/common/config/ScheduleConfig.java
+++ b/api/src/main/java/org/silsagusi/api/common/config/ScheduleConfig.java
@@ -126,7 +126,7 @@ public class ScheduleConfig {
 
 		for (Contract contract : expiredContracts) {
 			try {
-				Long agentId = contract.getCustomerLandlord().getAgent().getId();
+				Long agentId = contract.getAgent().getId();
 				String customerLandlordName = contract.getCustomerLandlord().getName();
 				String customerTenantName = contract.getCustomerTenant().getName();
 				String content = "고객 " + customerLandlordName + ", " + customerTenantName + "의 계약이 만료되었습니다.";

--- a/api/src/main/java/org/silsagusi/api/common/config/ScheduleConfig.java
+++ b/api/src/main/java/org/silsagusi/api/common/config/ScheduleConfig.java
@@ -11,6 +11,7 @@ import org.silsagusi.api.message.infrastructure.repository.MessageRepository;
 import org.silsagusi.api.notification.infrastructure.dataprovider.NotificationDataProvider;
 import org.silsagusi.core.domain.agent.Agent;
 import org.silsagusi.core.domain.consultation.entity.Consultation;
+import org.silsagusi.core.domain.consultation.enums.ConsultationStatus;
 import org.silsagusi.core.domain.contract.entity.Contract;
 import org.silsagusi.core.domain.customer.entity.Customer;
 import org.silsagusi.core.domain.message.entity.Message;
@@ -96,7 +97,7 @@ public class ScheduleConfig {
 		LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
 
 		List<Consultation> consultations = consultationRepository.findByDateBetweenAndConsultationStatusAndDeletedAtIsNull(
-			startOfDay, endOfDay, Consultation.ConsultationStatus.CONFIRMED);
+			startOfDay, endOfDay, ConsultationStatus.CONFIRMED);
 
 		for (Consultation consultation : consultations) {
 			try {

--- a/api/src/main/java/org/silsagusi/api/consultation/application/dto/ConsultationSummaryResponse.java
+++ b/api/src/main/java/org/silsagusi/api/consultation/application/dto/ConsultationSummaryResponse.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ConsultationSummaryResponse {
-	private Integer todayCount;
-	private Integer remainingCount;
+	private Long todayCount;
+	private Long remainingCount;
 
 	public static ConsultationSummaryResponse toResponse(ConsultationSummaryInfo info) {
 		return ConsultationSummaryResponse.builder()

--- a/api/src/main/java/org/silsagusi/api/consultation/application/mapper/ConsultationMapper.java
+++ b/api/src/main/java/org/silsagusi/api/consultation/application/mapper/ConsultationMapper.java
@@ -3,32 +3,35 @@ package org.silsagusi.api.consultation.application.mapper;
 import java.time.LocalDateTime;
 
 import org.silsagusi.api.consultation.application.dto.CreateConsultationRequest;
+import org.silsagusi.core.domain.agent.Agent;
 import org.silsagusi.core.domain.consultation.entity.Consultation;
+import org.silsagusi.core.domain.consultation.enums.ConsultationStatus;
 import org.silsagusi.core.domain.customer.entity.Customer;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ConsultationMapper {
 
-	public Consultation consultationRequestToEntity(Customer customer,
+	public Consultation consultationRequestToEntity(Agent agent, Customer customer,
 		CreateConsultationRequest consultationRequestDto) {
-		Consultation consultation = Consultation.create(
+		return Consultation.create(
+			agent,
 			customer,
 			consultationRequestDto.getDate(),
-			Consultation.ConsultationStatus.CONFIRMED
+			consultationRequestDto.getPurpose(),
+			consultationRequestDto.getMemo(),
+			ConsultationStatus.CONFIRMED
 		);
-
-		consultation.updateConsultation(consultation.getDate(), consultationRequestDto.getPurpose(),
-			consultationRequestDto.getMemo());
-
-		return consultation;
 	}
 
-	public Consultation answerRequestToEntity(Customer customer, LocalDateTime date) {
+	public Consultation answerRequestToEntity(Agent agent, Customer customer, LocalDateTime date) {
 		return Consultation.create(
+			agent,
 			customer,
 			date,
-			Consultation.ConsultationStatus.WAITING
+			null,
+			null,
+			ConsultationStatus.WAITING
 		);
 	}
 }

--- a/api/src/main/java/org/silsagusi/api/consultation/application/service/ConsultationService.java
+++ b/api/src/main/java/org/silsagusi/api/consultation/application/service/ConsultationService.java
@@ -3,6 +3,7 @@ package org.silsagusi.api.consultation.application.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.silsagusi.api.agent.infrastructure.dataprovider.AgentDataProvider;
 import org.silsagusi.api.consultation.application.dto.ConsultationHistoryResponse;
 import org.silsagusi.api.consultation.application.dto.ConsultationMonthResponse;
 import org.silsagusi.api.consultation.application.dto.ConsultationResponse;
@@ -13,6 +14,7 @@ import org.silsagusi.api.consultation.application.mapper.ConsultationMapper;
 import org.silsagusi.api.consultation.application.validator.ConsultationValidator;
 import org.silsagusi.api.consultation.infrastructure.dataprovider.ConsultationDataProvider;
 import org.silsagusi.api.customer.infrastructure.dataprovider.CustomerDataProvider;
+import org.silsagusi.core.domain.agent.Agent;
 import org.silsagusi.core.domain.consultation.command.UpdateConsultationCommand;
 import org.silsagusi.core.domain.consultation.entity.Consultation;
 import org.silsagusi.core.domain.consultation.info.ConsultationMonthInfo;
@@ -31,13 +33,16 @@ public class ConsultationService {
 
 	private final ConsultationDataProvider consultationDataProvider;
 	private final CustomerDataProvider customerDataProvider;
+	private final AgentDataProvider agentDataProvider;
 	private final ConsultationMapper consultationMapper;
 	private final ConsultationValidator consultationValidator;
 
 	@Transactional
-	public void createConsultation(CreateConsultationRequest createConsultationRequest) {
+	public void createConsultation(Long agentId, CreateConsultationRequest createConsultationRequest) {
+		Agent agent = agentDataProvider.getAgentById(agentId);
 		Customer customer = customerDataProvider.getCustomer(createConsultationRequest.getCustomerId());
-		Consultation consultation = consultationMapper.consultationRequestToEntity(customer, createConsultationRequest);
+		Consultation consultation = consultationMapper.consultationRequestToEntity(agent, customer,
+			createConsultationRequest);
 		consultationDataProvider.createConsultation(consultation);
 	}
 

--- a/api/src/main/java/org/silsagusi/api/consultation/controller/ConsultationController.java
+++ b/api/src/main/java/org/silsagusi/api/consultation/controller/ConsultationController.java
@@ -33,9 +33,10 @@ public class ConsultationController {
 
 	@PostMapping("/api/consultations")
 	public ResponseEntity<ApiResponse<Void>> createConsultation(
+		@CurrentAgentId Long agentId,
 		@RequestBody @Valid CreateConsultationRequest createConsultationRequest
 	) {
-		consultationService.createConsultation(createConsultationRequest);
+		consultationService.createConsultation(agentId, createConsultationRequest);
 		return ResponseEntity.ok(ApiResponse.ok());
 	}
 

--- a/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationCustomRepository.java
+++ b/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationCustomRepository.java
@@ -1,0 +1,10 @@
+package org.silsagusi.api.consultation.infrastructure.repository;
+
+import java.time.LocalDate;
+
+public interface ConsultationCustomRepository {
+
+	long countTodayConsultations(Long agentId, LocalDate today);
+
+	long countTodayRemaining(Long agentId, LocalDate today);
+}

--- a/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationCustomRepositoryImpl.java
+++ b/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationCustomRepositoryImpl.java
@@ -1,0 +1,58 @@
+package org.silsagusi.api.consultation.infrastructure.repository;
+
+import java.time.LocalDate;
+
+import org.silsagusi.core.domain.consultation.entity.QConsultation;
+import org.silsagusi.core.domain.consultation.enums.ConsultationStatus;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ConsultationCustomRepositoryImpl implements ConsultationCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public long countTodayConsultations(Long agentId, LocalDate today) {
+		QConsultation c = QConsultation.consultation;
+
+		Long count = queryFactory
+			.select(c.count())
+			.from(c)
+			.where(
+				c.date.between(today.atStartOfDay(), today.plusDays(1).atStartOfDay()),
+				c.customer.agent.id.eq(agentId),
+				c.consultationStatus.in(
+					ConsultationStatus.WAITING,
+					ConsultationStatus.CONFIRMED,
+					ConsultationStatus.COMPLETED
+				),
+				c.deletedAt.isNull()
+			)
+			.fetchOne();
+
+		return count != null ? count : 0;
+	}
+
+	@Override
+	public long countTodayRemaining(Long agentId, LocalDate today) {
+		QConsultation c = QConsultation.consultation;
+
+		Long count = queryFactory
+			.select(c.count())
+			.from(c)
+			.where(
+				c.date.between(today.atStartOfDay(), today.plusDays(1).atStartOfDay()),
+				c.customer.agent.id.eq(agentId),
+				c.consultationStatus.in(ConsultationStatus.WAITING, ConsultationStatus.CONFIRMED),
+				c.deletedAt.isNull()
+			)
+			.fetchOne();
+
+		return count != null ? count : 0;
+	}
+}

--- a/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationCustomRepositoryImpl.java
+++ b/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationCustomRepositoryImpl.java
@@ -23,7 +23,6 @@ public class ConsultationCustomRepositoryImpl implements ConsultationCustomRepos
 		Long count = queryFactory
 			.select(c.count())
 			.from(c)
-			.leftJoin(c.agent)
 			.where(
 				c.date.between(today.atStartOfDay(), today.plusDays(1).atStartOfDay()),
 				c.agent.id.eq(agentId),
@@ -46,7 +45,6 @@ public class ConsultationCustomRepositoryImpl implements ConsultationCustomRepos
 		Long count = queryFactory
 			.select(c.count())
 			.from(c)
-			.leftJoin(c.agent)
 			.where(
 				c.date.between(today.atStartOfDay(), today.plusDays(1).atStartOfDay()),
 				c.agent.id.eq(agentId),

--- a/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationCustomRepositoryImpl.java
+++ b/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationCustomRepositoryImpl.java
@@ -23,9 +23,10 @@ public class ConsultationCustomRepositoryImpl implements ConsultationCustomRepos
 		Long count = queryFactory
 			.select(c.count())
 			.from(c)
+			.leftJoin(c.agent)
 			.where(
 				c.date.between(today.atStartOfDay(), today.plusDays(1).atStartOfDay()),
-				c.customer.agent.id.eq(agentId),
+				c.agent.id.eq(agentId),
 				c.consultationStatus.in(
 					ConsultationStatus.WAITING,
 					ConsultationStatus.CONFIRMED,
@@ -45,9 +46,10 @@ public class ConsultationCustomRepositoryImpl implements ConsultationCustomRepos
 		Long count = queryFactory
 			.select(c.count())
 			.from(c)
+			.leftJoin(c.agent)
 			.where(
 				c.date.between(today.atStartOfDay(), today.plusDays(1).atStartOfDay()),
-				c.customer.agent.id.eq(agentId),
+				c.agent.id.eq(agentId),
 				c.consultationStatus.in(ConsultationStatus.WAITING, ConsultationStatus.CONFIRMED),
 				c.deletedAt.isNull()
 			)

--- a/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationRepository.java
+++ b/api/src/main/java/org/silsagusi/api/consultation/infrastructure/repository/ConsultationRepository.java
@@ -1,46 +1,26 @@
 package org.silsagusi.api.consultation.infrastructure.repository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.silsagusi.core.domain.consultation.entity.Consultation;
+import org.silsagusi.core.domain.consultation.enums.ConsultationStatus;
 import org.silsagusi.core.domain.customer.entity.Customer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface ConsultationRepository extends JpaRepository<Consultation, Long> {
+public interface ConsultationRepository extends JpaRepository<Consultation, Long>, ConsultationCustomRepository {
 
-	List<Consultation> findAllByCustomer_AgentIdAndDateBetweenAndDeletedAtIsNull(Long agentId, LocalDateTime startDate,
+	List<Consultation> findAllByAgent_IdAndDateBetweenAndDeletedAtIsNull(Long agentId, LocalDateTime startDate,
 		LocalDateTime endDate);
 
-	Integer countByCustomer_AgentIdAndDateBetweenAndDeletedAtIsNull(Long agentId, LocalDateTime startOfDay,
+	Integer countByAgent_IdAndDateBetweenAndDeletedAtIsNull(Long agentId, LocalDateTime startOfDay,
 		LocalDateTime endOfDay);
 
 	List<Consultation> findByDateBetweenAndConsultationStatusAndDeletedAtIsNull(LocalDateTime start, LocalDateTime end,
-		Consultation.ConsultationStatus status);
-
-	// 오늘 상담 전체 건수
-	@Query("SELECT COUNT(c) FROM Consultation c " +
-		"WHERE DATE(c.date) = :today " +
-		"AND c.customer.agent.id = :agentId " +
-		"AND c.consultationStatus IN ('WAITING', 'CONFIRMED', 'COMPLETED')" +
-		"AND c.deletedAt IS NULL"
-	)
-	int countTodayConsultations(@Param("agentId") Long agentId, @Param("today") LocalDate today);
-
-	// 오늘 남은 상담 (완료 안 된 것)
-	@Query("SELECT COUNT(c) FROM Consultation c " +
-		"WHERE DATE(c.date) = :today " +
-		"AND c.customer.agent.id = :agentId " +
-		"AND c.consultationStatus IN ('WAITING', 'CONFIRMED')" +
-		"AND c.deletedAt IS NULL"
-	)
-	int countTodayRemaining(@Param("agentId") Long agentId, @Param("today") LocalDate today);
+		ConsultationStatus status);
 
 	Optional<Consultation> findByIdAndDeletedAtIsNull(Long consultationId);
 
@@ -49,7 +29,6 @@ public interface ConsultationRepository extends JpaRepository<Consultation, Long
 	List<Consultation> findByCustomerAndDateBetweenAndDeletedAtIsNull(Customer customer, LocalDateTime start,
 		LocalDateTime end);
 
-	List<Consultation> findAllByCustomer_Agent_IdAndDateBetweenAndConsultationStatusAndDeletedAtIsNull(
-		Long customerAgentId, LocalDateTime start, LocalDateTime end,
-		Consultation.ConsultationStatus consultationStatus);
+	List<Consultation> findAllByAgent_IdAndDateBetweenAndConsultationStatusAndDeletedAtIsNull(
+		Long customerAgentId, LocalDateTime start, LocalDateTime end, ConsultationStatus consultationStatus);
 }

--- a/api/src/main/java/org/silsagusi/api/contract/application/mapper/ContractMapper.java
+++ b/api/src/main/java/org/silsagusi/api/contract/application/mapper/ContractMapper.java
@@ -1,6 +1,7 @@
 package org.silsagusi.api.contract.application.mapper;
 
 import org.silsagusi.api.contract.application.dto.CreateContractRequest;
+import org.silsagusi.core.domain.agent.Agent;
 import org.silsagusi.core.domain.contract.entity.Contract;
 import org.silsagusi.core.domain.customer.entity.Customer;
 import org.springframework.stereotype.Component;
@@ -8,11 +9,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class ContractMapper {
 
-	public Contract toEntity(
-		CreateContractRequest contractRequest, Customer customerLandlord,
-		Customer customerTenant, String filename
-	) {
+	public Contract toEntity(CreateContractRequest contractRequest, Agent agent, Customer customerLandlord,
+		Customer customerTenant, String filename) {
 		return Contract.create(
+			agent,
 			customerLandlord,
 			customerTenant,
 			contractRequest.getStartedAt(),

--- a/api/src/main/java/org/silsagusi/api/contract/application/service/ContractService.java
+++ b/api/src/main/java/org/silsagusi/api/contract/application/service/ContractService.java
@@ -1,8 +1,8 @@
 package org.silsagusi.api.contract.application.service;
 
-import java.io.IOException;
 import java.util.List;
 
+import org.silsagusi.api.agent.infrastructure.dataprovider.AgentDataProvider;
 import org.silsagusi.api.contract.application.dto.ContractDetailResponse;
 import org.silsagusi.api.contract.application.dto.ContractResponse;
 import org.silsagusi.api.contract.application.dto.ContractSummaryResponse;
@@ -12,6 +12,7 @@ import org.silsagusi.api.contract.application.mapper.ContractMapper;
 import org.silsagusi.api.contract.application.validator.ContractValidator;
 import org.silsagusi.api.contract.infrastructure.dataprovider.ContractDataProvider;
 import org.silsagusi.api.customer.infrastructure.dataprovider.CustomerDataProvider;
+import org.silsagusi.core.domain.agent.Agent;
 import org.silsagusi.core.domain.contract.entity.Contract;
 import org.silsagusi.core.domain.contract.info.ContractDetailInfo;
 import org.silsagusi.core.domain.contract.info.ContractInfo;
@@ -31,17 +32,18 @@ public class ContractService {
 
 	private final ContractDataProvider contractDataProvider;
 	private final CustomerDataProvider customerDataProvider;
+	private final AgentDataProvider agentDataProvider;
 	private final ContractMapper contractMapper;
 	private final ContractValidator contractValidator;
 
 	@Transactional
-	public void createContract(CreateContractRequest contractRequest, MultipartFile file) throws IOException {
+	public void createContract(Long agentId, CreateContractRequest contractRequest, MultipartFile file) {
+		Agent agent = agentDataProvider.getAgentById(agentId);
 		Customer customerLandlord = customerDataProvider.getCustomer(contractRequest.getLandlordId());
 		Customer customerTenant = customerDataProvider.getCustomer(contractRequest.getTenantId());
 
 		String filename = contractDataProvider.fileUpload(file);
-
-		Contract contract = contractMapper.toEntity(contractRequest, customerLandlord, customerTenant, filename);
+		Contract contract = contractMapper.toEntity(contractRequest, agent, customerLandlord, customerTenant, filename);
 
 		contractDataProvider.createContract(contract);
 	}

--- a/api/src/main/java/org/silsagusi/api/contract/application/validator/ContractValidator.java
+++ b/api/src/main/java/org/silsagusi/api/contract/application/validator/ContractValidator.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class ContractValidator {
 
 	public void validateAgentAccess(Long agentId, Contract contract) {
-		if (!contract.getCustomerLandlord().getAgent().getId().equals(agentId)) {
+		if (!contract.getAgent().getId().equals(agentId)) {
 			throw new CustomException(ErrorCode.FORBIDDEN);
 		}
 	}

--- a/api/src/main/java/org/silsagusi/api/contract/controller/ContractController.java
+++ b/api/src/main/java/org/silsagusi/api/contract/controller/ContractController.java
@@ -1,7 +1,5 @@
 package org.silsagusi.api.contract.controller;
 
-import java.io.IOException;
-
 import org.silsagusi.api.common.annotation.CurrentAgentId;
 import org.silsagusi.api.contract.application.dto.ContractDetailResponse;
 import org.silsagusi.api.contract.application.dto.ContractResponse;
@@ -34,10 +32,11 @@ public class ContractController {
 
 	@PostMapping(value = "/api/contracts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<ApiResponse<String>> createContract(
+		@CurrentAgentId Long agentId,
 		@RequestPart("contractData") @Valid CreateContractRequest contractRequestDto,
 		@RequestPart("file") MultipartFile file
-	) throws IOException {
-		contractService.createContract(contractRequestDto, file);
+	) {
+		contractService.createContract(agentId, contractRequestDto, file);
 		return ResponseEntity.ok(ApiResponse.ok());
 	}
 

--- a/api/src/main/java/org/silsagusi/api/contract/infrastructure/dataprovider/ContractDataProvider.java
+++ b/api/src/main/java/org/silsagusi/api/contract/infrastructure/dataprovider/ContractDataProvider.java
@@ -57,7 +57,6 @@ public class ContractDataProvider {
 	}
 
 	public ContractSummaryInfo getSummary(Long agentId) {
-
 		LocalDate today = LocalDate.now();
 		LocalDate sevenDaysAgo = today.minusDays(7);
 
@@ -71,8 +70,7 @@ public class ContractDataProvider {
 			rate = ((double)(todayCount - sevenDaysAgoCount) / sevenDaysAgoCount) * 100;
 		}
 
-		return ContractSummaryInfo.builder().count(todayCount).rate(rate).build();
-
+		return new ContractSummaryInfo(todayCount, rate);
 	}
 
 	public ContractDetailInfo getContractInfo(Contract contract) {
@@ -81,8 +79,8 @@ public class ContractDataProvider {
 		return contractDetailInfo;
 	}
 
-	public String fileUpload(MultipartFile file) throws IOException {
-		String filename = UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
+	public String fileUpload(MultipartFile file) {
+		String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
 
 		//meta data
 		ObjectMetadata objectMetadata = new ObjectMetadata();
@@ -90,9 +88,13 @@ public class ContractDataProvider {
 		objectMetadata.setContentLength(file.getSize());
 
 		//S3 upload
-		PutObjectRequest putObjectRequest = new PutObjectRequest("joonggaemoa", filename, file.getInputStream(),
-			objectMetadata);
-		amazonS3.putObject(putObjectRequest);
+		try {
+			PutObjectRequest putObjectRequest =
+				new PutObjectRequest(S3_BUCKET_NAME, filename, file.getInputStream(), objectMetadata);
+			amazonS3.putObject(putObjectRequest);
+		} catch (IOException e) {
+			throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
 
 		return filename;
 	}
@@ -103,7 +105,6 @@ public class ContractDataProvider {
 
 	public List<Contract> getExpiredContracts(Long agentId) {
 		LocalDate targetDate = LocalDate.now().plusMonths(6);
-		return contractRepository.findAllByCustomerLandlord_Agent_IdAndExpiredAtBeforeAndDeletedAtIsNull(
-			agentId, targetDate);
+		return contractRepository.findAllByAgent_IdAndExpiredAtBeforeAndDeletedAtIsNull(agentId, targetDate);
 	}
 }

--- a/api/src/main/java/org/silsagusi/api/contract/infrastructure/repository/ContractCustomRepository.java
+++ b/api/src/main/java/org/silsagusi/api/contract/infrastructure/repository/ContractCustomRepository.java
@@ -1,9 +1,15 @@
 package org.silsagusi.api.contract.infrastructure.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.silsagusi.core.domain.contract.entity.Contract;
+import org.silsagusi.core.domain.customer.entity.Customer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ContractCustomRepository {
 	Page<Contract> findContracts(Long agentId, String keyword, Pageable pageable);
+
+	List<Contract> findContractsByCustomerAndDateRange(Customer customer, LocalDate start, LocalDate end);
 }

--- a/api/src/main/java/org/silsagusi/api/contract/infrastructure/repository/ContractRepository.java
+++ b/api/src/main/java/org/silsagusi/api/contract/infrastructure/repository/ContractRepository.java
@@ -5,31 +5,23 @@ import java.util.List;
 import java.util.Optional;
 
 import org.silsagusi.core.domain.contract.entity.Contract;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ContractRepository extends JpaRepository<Contract, String>, ContractCustomRepository {
-	Page<Contract> findAllByCustomerLandlord_AgentIdAndDeletedAtIsNull(Long agentId, Pageable pageable);
 
-	@EntityGraph(attributePaths = {"customerLandlord", "customerTenant"})
+	@EntityGraph(attributePaths = {"agent", "customerLandlord", "customerTenant"})
 	List<Contract> findByExpiredAtAndDeletedAtIsNull(LocalDate expiredAt);
 
-	@Query("SELECT COUNT(c) FROM Contract c WHERE c.customerLandlord.agent.id = :agentId " +
-		"AND c.startedAt <= :today AND c.expiredAt >= :today AND c.deletedAt IS NULL"
-	)
+	@Query("SELECT COUNT(c) FROM Contract c WHERE c.agent.id = :agentId " +
+		"AND c.startedAt <= :today AND c.expiredAt >= :today AND c.deletedAt IS NULL")
 	long countInProgress(@Param("agentId") Long agentId, @Param("today") LocalDate today);
 
-	// 특정 날짜에 생성된 계약 수
-	long countByCustomerLandlord_Agent_IdAndStartedAt(Long agentId, LocalDate startedAt);
-
-	@EntityGraph(attributePaths = {"customerLandlord", "customerTenant"})
+	@EntityGraph(attributePaths = {"agent", "customerLandlord", "customerTenant"})
 	Optional<Contract> findByIdAndDeletedAtIsNull(String contractId);
 
 	@EntityGraph(attributePaths = {"customerLandlord", "customerTenant"})
-	List<Contract> findAllByCustomerLandlord_Agent_IdAndExpiredAtBeforeAndDeletedAtIsNull(Long agentId,
-		LocalDate expiredAtBefore);
+	List<Contract> findAllByAgent_IdAndExpiredAtBeforeAndDeletedAtIsNull(Long agentId, LocalDate expiredAt);
 }

--- a/api/src/main/java/org/silsagusi/api/contract/infrastructure/repository/ContractRepository.java
+++ b/api/src/main/java/org/silsagusi/api/contract/infrastructure/repository/ContractRepository.java
@@ -5,9 +5,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.silsagusi.core.domain.contract.entity.Contract;
-import org.silsagusi.core.domain.customer.entity.Customer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +15,7 @@ import org.springframework.data.repository.query.Param;
 public interface ContractRepository extends JpaRepository<Contract, String>, ContractCustomRepository {
 	Page<Contract> findAllByCustomerLandlord_AgentIdAndDeletedAtIsNull(Long agentId, Pageable pageable);
 
+	@EntityGraph(attributePaths = {"customerLandlord", "customerTenant"})
 	List<Contract> findByExpiredAtAndDeletedAtIsNull(LocalDate expiredAt);
 
 	@Query("SELECT COUNT(c) FROM Contract c WHERE c.customerLandlord.agent.id = :agentId " +
@@ -25,25 +26,10 @@ public interface ContractRepository extends JpaRepository<Contract, String>, Con
 	// 특정 날짜에 생성된 계약 수
 	long countByCustomerLandlord_Agent_IdAndStartedAt(Long agentId, LocalDate startedAt);
 
+	@EntityGraph(attributePaths = {"customerLandlord", "customerTenant"})
 	Optional<Contract> findByIdAndDeletedAtIsNull(String contractId);
 
-	@Query("""
-		    SELECT c FROM Contract c
-		    WHERE 
-		        (c.customerLandlord = :customer OR c.customerTenant = :customer)
-		        AND (
-		            (c.createdAt BETWEEN :start AND :end)
-		            OR
-		            (c.expiredAt BETWEEN :start AND :end)
-		        )
-				        AND c.deletedAt IS NULL
-		""")
-	List<Contract> findContractsByCustomerAndDateRange(
-		@Param("customer") Customer customer,
-		@Param("start") LocalDate start,
-		@Param("end") LocalDate end
-	);
-
+	@EntityGraph(attributePaths = {"customerLandlord", "customerTenant"})
 	List<Contract> findAllByCustomerLandlord_Agent_IdAndExpiredAtBeforeAndDeletedAtIsNull(Long agentId,
 		LocalDate expiredAtBefore);
 }

--- a/api/src/main/java/org/silsagusi/api/customer/application/service/CustomerService.java
+++ b/api/src/main/java/org/silsagusi/api/customer/application/service/CustomerService.java
@@ -100,7 +100,6 @@ public class CustomerService {
 
 	@Transactional(readOnly = true)
 	public CustomerSummaryResponse getCustomerSummary(Long agentId) {
-
 		CustomerSummaryInfo customerSummaryInfo = customerDataProvider.getCustomerSummary(agentId);
 
 		return CustomerSummaryResponse.toResponse(customerSummaryInfo);

--- a/api/src/main/java/org/silsagusi/api/customer/infrastructure/dataprovider/CustomerDataProvider.java
+++ b/api/src/main/java/org/silsagusi/api/customer/infrastructure/dataprovider/CustomerDataProvider.java
@@ -149,16 +149,16 @@ public class CustomerDataProvider {
 	}
 
 	public CustomerSummaryInfo getCustomerSummary(Long agentId) {
+		LocalDate today = LocalDate.now();
 		LocalDateTime now = LocalDateTime.now();
 
-		LocalDate today = LocalDate.now();
-		LocalDate thisWeekStart = today.with(DayOfWeek.MONDAY);
-		LocalDateTime thisWeekStartTime = thisWeekStart.atStartOfDay();
+		LocalDate thisWeekStartDate = today.with(DayOfWeek.MONDAY);
+		LocalDate lastWeekStartDate = thisWeekStartDate.minusWeeks(1);
+		LocalDate lastWeekEndDate = thisWeekStartDate.minusDays(1);
 
-		LocalDate lastWeekStart = thisWeekStart.minusWeeks(1);
-		LocalDate lastWeekEnd = thisWeekStart.minusDays(1);
-		LocalDateTime lastWeekStartTime = lastWeekStart.atStartOfDay();
-		LocalDateTime lastWeekEndTime = lastWeekEnd.atTime(LocalTime.MAX);
+		LocalDateTime thisWeekStartTime = thisWeekStartDate.atStartOfDay();
+		LocalDateTime lastWeekStartTime = lastWeekStartDate.atStartOfDay();
+		LocalDateTime lastWeekEndTime = lastWeekEndDate.atTime(LocalTime.MAX);
 
 		Long thisWeekCount = customerRepository.countByAgentIdAndCreatedAtBetweenAndDeletedAtIsNull(agentId,
 			thisWeekStartTime, now);
@@ -172,7 +172,7 @@ public class CustomerDataProvider {
 			changeRate = ((double)(thisWeekCount - lastWeekCount) / lastWeekCount) * 100;
 		}
 
-		return CustomerSummaryInfo.builder().count(thisWeekCount).rate(changeRate).build();
+		return new CustomerSummaryInfo(thisWeekCount, changeRate);
 	}
 
 	public List<Customer> getCustomerListByIdList(List<Long> customerIdList) {

--- a/api/src/main/java/org/silsagusi/api/customer/infrastructure/dataprovider/CustomerDataProvider.java
+++ b/api/src/main/java/org/silsagusi/api/customer/infrastructure/dataprovider/CustomerDataProvider.java
@@ -90,16 +90,15 @@ public class CustomerDataProvider {
 		LocalDateTime endDate = now.plusMonths(3);
 
 		consultationRepository.findByCustomerAndDateBetweenAndDeletedAtIsNull(customer, startDate, endDate)
-			.forEach(consultation -> {
+			.forEach(consultation ->
 				customerHistoryInfos.add(
 					CustomerHistoryInfo.builder()
 						.id(consultation.getId() + "")
 						.type("CONSULTATION")
 						.date(consultation.getDate())
 						.purpose(consultation.getPurpose())
-						.build()
-				);
-			});
+						.build())
+			);
 
 		contractRepository.findContractsByCustomerAndDateRange(customer, startDate.toLocalDate(), endDate.toLocalDate())
 			.forEach(contract -> {
@@ -119,12 +118,11 @@ public class CustomerDataProvider {
 						.role(role)
 						.startDate(contract.getStartedAt())
 						.endDate(contract.getExpiredAt())
-						.build(
-						));
+						.build());
 			});
 
 		messageRepository.findByCustomerAndSendAtBetweenAndDeletedAtIsNull(customer, startDate, endDate)
-			.forEach(message -> {
+			.forEach(message ->
 				customerHistoryInfos.add(
 					CustomerHistoryInfo.builder()
 						.id(message.getId() + "")
@@ -132,21 +130,19 @@ public class CustomerDataProvider {
 						.date(message.getSendAt())
 						.content(message.getContent())
 						.sendStatus(message.getSendStatus() + "")
-						.build()
-				);
-			});
+						.build())
+			);
 
 		answerRepository.findAllByCustomerAndCreatedAtBetweenAndDeletedAtIsNull(
 				customer, startDate, endDate)
-			.forEach(answer -> {
+			.forEach(answer ->
 				customerHistoryInfos.add(
 					CustomerHistoryInfo.builder()
 						.id(answer.getId() + "")
 						.type("SURVEY")
 						.date(answer.getCreatedAt())
-						.build()
-				);
-			});
+						.build())
+			);
 
 		customerHistoryInfos.sort(Comparator.comparing(CustomerHistoryInfo::getSortDate).reversed());
 		return customerHistoryInfos;

--- a/api/src/main/java/org/silsagusi/api/inquiry/application/dto/InquiryResponse.java
+++ b/api/src/main/java/org/silsagusi/api/inquiry/application/dto/InquiryResponse.java
@@ -24,7 +24,7 @@ public class InquiryResponse {
 			.title(inquiry.getTitle())
 			.content(inquiry.getContent())
 			.createdAt(inquiry.getCreatedAt())
-			.count(inquiry.getAnswers().size())
+			.count(inquiry.getAnswerCount())
 			.build();
 	}
 }

--- a/api/src/main/java/org/silsagusi/api/inquiry/application/service/InquiryService.java
+++ b/api/src/main/java/org/silsagusi/api/inquiry/application/service/InquiryService.java
@@ -88,7 +88,7 @@ public class InquiryService {
 	public void createInquiryAnswer(Long agentId, Long inquiryId, CreateInquiryAnswerRequest inquiryAnswerRequest) {
 		Inquiry inquiry = inquiryDataProvider.getInquiry(inquiryId);
 		Agent agent = agentDataProvider.getAgentById(agentId);
-		inquiryDataProvider.markAsAnswered(inquiry);
+		inquiryDataProvider.increaseAnswerCount(inquiry);
 		InquiryAnswer inquiryAnswer = inquiryAnswerMapper.toEntity(inquiry, agent, inquiryAnswerRequest);
 		inquiryDataProvider.createInquiryAnswer(inquiryAnswer);
 	}

--- a/api/src/main/java/org/silsagusi/api/inquiry/application/service/InquiryService.java
+++ b/api/src/main/java/org/silsagusi/api/inquiry/application/service/InquiryService.java
@@ -102,7 +102,7 @@ public class InquiryService {
 			customerDataProvider.createCustomer(customer);
 		}
 
-		Consultation consultation = consultationMapper.answerRequestToEntity(customer,
+		Consultation consultation = consultationMapper.answerRequestToEntity(agent, customer,
 			createConsultationRequest.getConsultAt());
 		consultationDataProvider.createConsultation(consultation);
 

--- a/api/src/main/java/org/silsagusi/api/inquiry/infrastructure/dataprovider/InquiryDataProvider.java
+++ b/api/src/main/java/org/silsagusi/api/inquiry/infrastructure/dataprovider/InquiryDataProvider.java
@@ -45,7 +45,10 @@ public class InquiryDataProvider {
 		inquiryAnswerRepository.save(inquiryAnswer);
 	}
 
-	public void markAsAnswered(Inquiry inquiry) {
-		inquiry.markAsAnswered();
+	public void increaseAnswerCount(Inquiry inquiry) {
+		if (!inquiry.isAnswered()) {
+			inquiry.markAsAnswered();
+		}
+		inquiry.increaseAnswerCount();
 	}
 }

--- a/api/src/main/java/org/silsagusi/api/inquiry/infrastructure/repository/InquiryRepository.java
+++ b/api/src/main/java/org/silsagusi/api/inquiry/infrastructure/repository/InquiryRepository.java
@@ -5,9 +5,11 @@ import java.util.Optional;
 import org.silsagusi.core.domain.inquiry.entity.Inquiry;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+	@EntityGraph(attributePaths = "answers")
 	Optional<Inquiry> findByIdAndDeletedAtIsNull(Long inquiryId);
 
 	Page<Inquiry> findAllByDeletedAtIsNull(Pageable pageable);

--- a/api/src/main/java/org/silsagusi/api/survey/application/service/SurveyService.java
+++ b/api/src/main/java/org/silsagusi/api/survey/application/service/SurveyService.java
@@ -110,7 +110,7 @@ public class SurveyService {
 		}
 
 		if (Boolean.TRUE.equals(submitAnswerRequest.getApplyConsultation())) {
-			Consultation consultation = consultationMapper.answerRequestToEntity(customer,
+			Consultation consultation = consultationMapper.answerRequestToEntity(agent, customer,
 				submitAnswerRequest.getConsultAt());
 			consultationDataProvider.createConsultation(consultation);
 

--- a/core/src/main/java/org/silsagusi/core/domain/consultation/entity/Consultation.java
+++ b/core/src/main/java/org/silsagusi/core/domain/consultation/entity/Consultation.java
@@ -18,6 +18,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -28,7 +29,9 @@ import lombok.NoArgsConstructor;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "consultations")
+@Table(name = "consultations", indexes = {
+	@Index(name = "idx_consultation_agent_date_status_deleted", columnList = "agent_id, date, consultation_status, deleted_at")
+})
 @Getter
 public class Consultation extends BaseEntity {
 

--- a/core/src/main/java/org/silsagusi/core/domain/consultation/entity/Consultation.java
+++ b/core/src/main/java/org/silsagusi/core/domain/consultation/entity/Consultation.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.DynamicUpdate;
 import org.silsagusi.core.domain.BaseEntity;
+import org.silsagusi.core.domain.agent.Agent;
+import org.silsagusi.core.domain.consultation.enums.ConsultationStatus;
 import org.silsagusi.core.domain.customer.entity.Customer;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -36,6 +38,10 @@ public class Consultation extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "agent_id", nullable = false)
+	private Agent agent;
+
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "customer_id", nullable = false)
 	private Customer customer;
 
@@ -50,39 +56,28 @@ public class Consultation extends BaseEntity {
 	@Column(name = "consultation_status")
 	private ConsultationStatus consultationStatus;
 
-	private Consultation(
-		Customer customer,
-		LocalDateTime date,
-		ConsultationStatus consultationStatus
-	) {
+	private Consultation(Agent agent, Customer customer, LocalDateTime date, String purpose, String memo,
+		ConsultationStatus consultationStatus) {
+		this.agent = agent;
 		this.customer = customer;
 		this.date = date;
+		this.purpose = purpose;
+		this.memo = memo;
 		this.consultationStatus = consultationStatus;
 	}
 
-	public static Consultation create(Customer customer, LocalDateTime date, ConsultationStatus consultationStatus) {
-		return new Consultation(customer, date, consultationStatus);
+	public static Consultation create(Agent agent, Customer customer, LocalDateTime date, String purpose, String memo,
+		ConsultationStatus consultationStatus) {
+		return new Consultation(agent, customer, date, purpose, memo, consultationStatus);
 	}
 
 	public void updateStatus(ConsultationStatus consultationStatus) {
 		this.consultationStatus = consultationStatus;
 	}
 
-	public void updateConsultation(
-		LocalDateTime date,
-		String purpose,
-		String memo
-	) {
+	public void updateConsultation(LocalDateTime date, String purpose, String memo) {
 		this.date = date;
 		this.purpose = purpose;
 		this.memo = memo;
 	}
-
-	public enum ConsultationStatus {
-		WAITING,     // 상담 예약 대기
-		CONFIRMED,   // 예약 확정
-		CANCELED,    // 예약 취소
-		COMPLETED    // 진행 완료
-	}
-
 }

--- a/core/src/main/java/org/silsagusi/core/domain/consultation/enums/ConsultationStatus.java
+++ b/core/src/main/java/org/silsagusi/core/domain/consultation/enums/ConsultationStatus.java
@@ -1,0 +1,8 @@
+package org.silsagusi.core.domain.consultation.enums;
+
+public enum ConsultationStatus {
+	WAITING,     // 상담 예약 대기
+	CONFIRMED,   // 예약 확정
+	CANCELED,    // 예약 취소
+	COMPLETED    // 진행 완료
+}

--- a/core/src/main/java/org/silsagusi/core/domain/consultation/info/ConsultationSummaryInfo.java
+++ b/core/src/main/java/org/silsagusi/core/domain/consultation/info/ConsultationSummaryInfo.java
@@ -1,12 +1,12 @@
 package org.silsagusi.core.domain.consultation.info;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@Builder
 @Getter
+@AllArgsConstructor
 public class ConsultationSummaryInfo {
-    private Integer todayCount;
-    private Integer remainingCount;
+	private Long todayCount;
+	private Long remainingCount;
 }
 

--- a/core/src/main/java/org/silsagusi/core/domain/contract/entity/Contract.java
+++ b/core/src/main/java/org/silsagusi/core/domain/contract/entity/Contract.java
@@ -3,6 +3,7 @@ package org.silsagusi.core.domain.contract.entity;
 import java.time.LocalDate;
 
 import org.silsagusi.core.domain.BaseEntity;
+import org.silsagusi.core.domain.agent.Agent;
 import org.silsagusi.core.domain.customer.entity.Customer;
 
 import jakarta.persistence.Column;
@@ -11,6 +12,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -20,7 +22,10 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "contracts")
+@Table(name = "contracts", indexes = {
+	@Index(name = "idx_contract_agent_expired_deleted", columnList = "agent_id, expired_at, deleted_at"),
+	@Index(name = "idx_contract_agent_started_expired_deleted", columnList = "agent_id, started_at, expired_at, deleted_at")
+})
 @Getter
 public class Contract extends BaseEntity {
 
@@ -28,6 +33,10 @@ public class Contract extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.UUID)
 	@Column(name = "contract_id")
 	private String id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "agent_id")
+	private Agent agent;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "landlord_id")
@@ -45,13 +54,9 @@ public class Contract extends BaseEntity {
 
 	private String url;
 
-	private Contract(
-		Customer customerLandlordId,
-		Customer customerTenantId,
-		LocalDate startedAt,
-		LocalDate expiredAt,
-		String url
-	) {
+	private Contract(Agent agent, Customer customerLandlordId, Customer customerTenantId, LocalDate startedAt,
+		LocalDate expiredAt, String url) {
+		this.agent = agent;
 		this.customerLandlord = customerLandlordId;
 		this.customerTenant = customerTenantId;
 		this.startedAt = startedAt;
@@ -59,19 +64,8 @@ public class Contract extends BaseEntity {
 		this.url = url;
 	}
 
-	public static Contract create(
-		Customer customerLandlordId,
-		Customer customerTenantId,
-		LocalDate startedAt,
-		LocalDate expiredAt,
-		String url
-	) {
-		return new Contract(
-			customerLandlordId,
-			customerTenantId,
-			startedAt,
-			expiredAt,
-			url
-		);
+	public static Contract create(Agent agent, Customer customerLandlordId, Customer customerTenantId,
+		LocalDate startedAt, LocalDate expiredAt, String url) {
+		return new Contract(agent, customerLandlordId, customerTenantId, startedAt, expiredAt, url);
 	}
 }

--- a/core/src/main/java/org/silsagusi/core/domain/contract/info/ContractDetailInfo.java
+++ b/core/src/main/java/org/silsagusi/core/domain/contract/info/ContractDetailInfo.java
@@ -3,6 +3,7 @@ package org.silsagusi.core.domain.contract.info;
 import java.time.LocalDate;
 
 import org.silsagusi.core.domain.contract.entity.Contract;
+import org.silsagusi.core.domain.customer.entity.Customer;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -26,16 +27,19 @@ public class ContractDetailInfo {
 	private String url;
 
 	public static ContractDetailInfo of(Contract contract) {
+		Customer customerLandlord = contract.getCustomerLandlord();
+		Customer customerTenant = contract.getCustomerTenant();
+
 		return ContractDetailInfo.builder()
 			.id(contract.getId())
-			.landlordId(contract.getCustomerLandlord().getId())
-			.tenantId(contract.getCustomerTenant().getId())
-			.landlordName(contract.getCustomerLandlord().getName())
-			.tenantName(contract.getCustomerTenant().getName())
-			.landlordPhone(contract.getCustomerLandlord().getPhone())
-			.tenantPhone(contract.getCustomerTenant().getPhone())
-			.landlordEmail(contract.getCustomerLandlord().getEmail())
-			.tenantEmail(contract.getCustomerTenant().getEmail())
+			.landlordId(customerLandlord.getId())
+			.tenantId(customerTenant.getId())
+			.landlordName(customerLandlord.getName())
+			.tenantName(customerTenant.getName())
+			.landlordPhone(customerLandlord.getPhone())
+			.tenantPhone(customerTenant.getPhone())
+			.landlordEmail(customerLandlord.getEmail())
+			.tenantEmail(customerTenant.getEmail())
 			.startedAt(contract.getStartedAt())
 			.expiredAt(contract.getExpiredAt())
 			.build();

--- a/core/src/main/java/org/silsagusi/core/domain/contract/info/ContractSummaryInfo.java
+++ b/core/src/main/java/org/silsagusi/core/domain/contract/info/ContractSummaryInfo.java
@@ -1,10 +1,10 @@
 package org.silsagusi.core.domain.contract.info;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@Builder
+@AllArgsConstructor
 public class ContractSummaryInfo {
 	private Long count;
 	private Double rate;

--- a/core/src/main/java/org/silsagusi/core/domain/customer/info/CustomerSummaryInfo.java
+++ b/core/src/main/java/org/silsagusi/core/domain/customer/info/CustomerSummaryInfo.java
@@ -1,10 +1,10 @@
 package org.silsagusi.core.domain.customer.info;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@Builder
+@AllArgsConstructor
 public class CustomerSummaryInfo {
 	private Long count;
 	private Double rate;

--- a/core/src/main/java/org/silsagusi/core/domain/inquiry/entity/Inquiry.java
+++ b/core/src/main/java/org/silsagusi/core/domain/inquiry/entity/Inquiry.java
@@ -39,6 +39,9 @@ public class Inquiry extends BaseEntity {
 	@Lob
 	private String content;
 
+	@Column(name = "answer_count")
+	private Integer answerCount;
+
 	@Column(name = "is_answered")
 	private boolean isAnswered;
 
@@ -50,6 +53,7 @@ public class Inquiry extends BaseEntity {
 		this.password = password;
 		this.title = title;
 		this.content = content;
+		this.answerCount = 0;
 	}
 
 	public static Inquiry create(String name, String password, String title, String content) {
@@ -63,6 +67,10 @@ public class Inquiry extends BaseEntity {
 
 	public void markAsAnswered() {
 		this.isAnswered = true;
+	}
+
+	public void increaseAnswerCount() {
+		this.answerCount++;
 	}
 
 }

--- a/core/src/main/java/org/silsagusi/core/domain/notification/entity/Notification.java
+++ b/core/src/main/java/org/silsagusi/core/domain/notification/entity/Notification.java
@@ -9,12 +9,15 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "notifications")
+@Table(name = "notifications", indexes = {
+	@Index(name = "idx_notification_agent", columnList = "agent_id")
+})
 @Getter
 @NoArgsConstructor
 public class Notification extends BaseEntity {


### PR DESCRIPTION
## 💡 개요
유저가 로그인하고 대시보드에 입장하면 약 10개의 API 호출이 나가는데, 쿼리 개선&인덱스 적용으로 속도를 개선하였습니다
결과 : 119ms -> 76ms

+추가
기존에는 Agent -> Customer -> Contract같이 이어지는 경우 Agent와 Contract의 연관관계를 끊었었는데 단방향으로 참조시 순환이 생기지 않아 Contract에 Agent을 추가하였습니다

Resolves: #269 

## 🔧 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 배포 및 PR 관련

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
